### PR TITLE
Improve qawolf.yml

### DIFF
--- a/.github/workflows/qawolf.yml
+++ b/.github/workflows/qawolf.yml
@@ -33,10 +33,10 @@ jobs:
 
       - run: npm install
 
-      # - name: Start local server
-      #   run: npm run start & npx wait-on http://localhost:3000
+      - name: Start local server
+        run: npm run start & npx wait-on http://localhost:3000
 
-      - run: npx qawolf test
+      - run: npm run e2e
         env:
           QAW_ARTIFACT_PATH: ${{ github.workspace }}/artifacts
         #   # configure tests with environment variables

--- a/e2e/tests/example.test.js
+++ b/e2e/tests/example.test.js
@@ -5,7 +5,7 @@ describe('example', () => {
   let browser;
 
   beforeAll(async () => {
-    browser = await launch({ url: "https://http//localhost:3030" });
+    browser = await launch({ url: "localhost:3000" });
   });
 
   afterAll(() => browser.close());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1933,63 +1933,63 @@
       }
     },
     "@qawolf/browser": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/browser/-/browser-0.9.0.tgz",
-      "integrity": "sha512-CtaBFZHwRioPRApmzWGWWNoaIuLQIj4otNvKkaCDm0vtBtqLxB4Dkiqg2WKuuzHoe12LMZndTSXGimL9QLFQpw==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@qawolf/browser/-/browser-0.9.2.tgz",
+      "integrity": "sha512-HpSe8IAlelg+tcN04sz+oFfrD7w6IWDeZ0/PwUiDXaXs9XBthXET32Luh/hM2F67N9RLvJ0Wr3aGnQItRWSmVw==",
       "dev": true,
       "requires": {
-        "@qawolf/config": "0.9.0",
-        "@qawolf/logger": "0.9.0",
-        "@qawolf/repl": "0.9.0",
-        "@qawolf/screen": "0.9.0",
-        "@qawolf/types": "0.9.0",
-        "@qawolf/web": "0.9.0",
+        "@qawolf/config": "0.9.2",
+        "@qawolf/logger": "0.9.2",
+        "@qawolf/repl": "0.9.2",
+        "@qawolf/screen": "0.9.2",
+        "@qawolf/types": "0.9.2",
+        "@qawolf/web": "0.9.2",
         "rrweb": "^0.7.25"
       }
     },
     "@qawolf/build-code": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/build-code/-/build-code-0.9.0.tgz",
-      "integrity": "sha512-HvNTZYIjvpplZAEATxYEzg8hAKb6n6ROdoaA89pn42JXOD0opnv78iLqGrhwVl3xenaZ5OF+9C9umX2QNtWDhg==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@qawolf/build-code/-/build-code-0.9.2.tgz",
+      "integrity": "sha512-j4wLjbq2QCRsi3Wbeb09H+6RPFY8818d/t49L67h0f/STA+KKUe+Oe8l0p8GV0b7IikJgrzcLTyY2vmdEEb6kw==",
       "dev": true,
       "requires": {
-        "@qawolf/build-workflow": "0.9.0",
-        "@qawolf/config": "0.9.0",
-        "@qawolf/logger": "0.9.0",
-        "@qawolf/types": "0.9.0",
-        "@qawolf/web": "0.9.0"
+        "@qawolf/build-workflow": "0.9.2",
+        "@qawolf/config": "0.9.2",
+        "@qawolf/logger": "0.9.2",
+        "@qawolf/types": "0.9.2",
+        "@qawolf/web": "0.9.2"
       }
     },
     "@qawolf/build-workflow": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/build-workflow/-/build-workflow-0.9.0.tgz",
-      "integrity": "sha512-kauVCeCee2NhIci6YUyg7iDmLjdMkHMlMDZ9enjxjrI9d/k2NpDshi+C7yP6w/21mkX3KivnrFGwLTV+o23asg==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@qawolf/build-workflow/-/build-workflow-0.9.2.tgz",
+      "integrity": "sha512-zXzRSWbbESn9DDc2n64CXBjAo6vakCzzL0n8qfGinCzTArsQalRgDkBJOkp1G9aFgNL47CJFQpxSh5HCH9/7sA==",
       "dev": true,
       "requires": {
-        "@qawolf/browser": "0.9.0",
-        "@qawolf/logger": "0.9.0",
-        "@qawolf/web": "0.9.0"
+        "@qawolf/browser": "0.9.2",
+        "@qawolf/logger": "0.9.2",
+        "@qawolf/web": "0.9.2"
       }
     },
     "@qawolf/config": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/config/-/config-0.9.0.tgz",
-      "integrity": "sha512-9XljwRzSzeqQWtLenjqyjnT4lxNU2SjLkHml/o9cqfjHCi72VyUNXCpSPxEU0oHei0lbBJi99fkTxJuHLaVytg==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@qawolf/config/-/config-0.9.2.tgz",
+      "integrity": "sha512-MOR11NFu9GWcbTwBpPshyGCsIuV4XaLtucTD4stXFI3EPJTGcb/YLK5Y9KhQmInav157hWOFcdtKGmf8Z1H1bA==",
       "dev": true,
       "requires": {
         "dotenv": "^8.1.0"
       }
     },
     "@qawolf/create-code": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/create-code/-/create-code-0.9.0.tgz",
-      "integrity": "sha512-QgS88+UWtK9wvLKtOn4VFb3kf+OEJj4I6CCFX8X6E1v1WBP0cMRHztEM2azP6GbWL7oSDDQ08DwIvHBr/VMRRw==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@qawolf/create-code/-/create-code-0.9.2.tgz",
+      "integrity": "sha512-c/Rz1hgBi4SaeXNes9xJtjGdrFESh5Zokya4lXDEmiWydOt+2XjVqGy5WiqZt1krCag8Wo+14KI2rSZHrFIlCg==",
       "dev": true,
       "requires": {
-        "@qawolf/build-code": "0.9.0",
-        "@qawolf/build-workflow": "0.9.0",
-        "@qawolf/logger": "0.9.0",
-        "@qawolf/repl": "0.9.0"
+        "@qawolf/build-code": "0.9.2",
+        "@qawolf/build-workflow": "0.9.2",
+        "@qawolf/logger": "0.9.2",
+        "@qawolf/repl": "0.9.2"
       }
     },
     "@qawolf/jasmine-fail-fast": {
@@ -2002,55 +2002,55 @@
       }
     },
     "@qawolf/jest-plugin": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/jest-plugin/-/jest-plugin-0.9.0.tgz",
-      "integrity": "sha512-qmnrhO6lkgsXWq3XTHrLdCCcDCb3ExFoQJvriG33l7tNHTa2ubRPMoJFfYkTQtcQ777LhHnDtjNTleg6slYqyA==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@qawolf/jest-plugin/-/jest-plugin-0.9.2.tgz",
+      "integrity": "sha512-7BGIJMrNDXWM1KnO99jhL/IKwXmBJMtFytBgYoZr+WCbGnMB1GzFsI+0HUUIJ5QBHsUnIpDGbVY1g30MnrZ/lQ==",
       "dev": true,
       "requires": {
         "@qawolf/jasmine-fail-fast": "^2.0.1"
       }
     },
     "@qawolf/logger": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/logger/-/logger-0.9.0.tgz",
-      "integrity": "sha512-EQg6B+YQVtMCWfZLkTKg3+ABoXuPtzHq9Zd7/NEzxwFi7plnOppkt6Opd1/5QuG9E+JnOV++YZBN2uYJcv8OOw==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@qawolf/logger/-/logger-0.9.2.tgz",
+      "integrity": "sha512-f11GOjaPFnkG3mESy8C5i0L3jDGePwbwYiiGOG1NxxJfd/OOb5hpNLGfdPIhvF3sRy9FOafN6gwh7klm510XQA==",
       "dev": true,
       "requires": {
-        "@qawolf/config": "0.9.0",
+        "@qawolf/config": "0.9.2",
         "winston": "^3.2.1"
       }
     },
     "@qawolf/repl": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/repl/-/repl-0.9.0.tgz",
-      "integrity": "sha512-978UuT2Q1gZagqO34BggYerxmlm9YcSljVXut9umhOyyGyz8gOwo4JgSau1L04CMnzie2KuKeXPr8qhIQ4rRLw==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@qawolf/repl/-/repl-0.9.2.tgz",
+      "integrity": "sha512-UJXlDVWHmPL2D47ko5lWeKzxW0v3SLX80ZtvfCQoYgL7vWW3TDgMPX77QGNXZITItkBeP0ZFVxUPpDDNom8cfA==",
       "dev": true,
       "requires": {
-        "@qawolf/logger": "0.9.0",
+        "@qawolf/logger": "0.9.2",
         "await-outside": "^3.0.0"
       }
     },
     "@qawolf/screen": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/screen/-/screen-0.9.0.tgz",
-      "integrity": "sha512-XE8ljG0GUIBbti+2R8eKQRJmq8CuRI6LqajtU+1fIopoLfDg9APq56k9kp+avTbi5v0iA4Rub84Z4xiyreaVrA==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@qawolf/screen/-/screen-0.9.2.tgz",
+      "integrity": "sha512-rDWaw4SpwqsIFaT4f1LPyN5y+maOsFPRyTiiYRjnoPmy+9MBjyfgfeZNe4Ya2HxoJ3E0y2qhcALfwNPfHgdu7Q==",
       "dev": true,
       "requires": {
-        "@qawolf/logger": "0.9.0",
-        "@qawolf/web": "0.9.0",
+        "@qawolf/logger": "0.9.2",
+        "@qawolf/web": "0.9.2",
         "ffmpeg-static": "4.0.0"
       }
     },
     "@qawolf/types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/types/-/types-0.9.0.tgz",
-      "integrity": "sha512-YGMRSBJV5CNtDnRAlBTH6S7aYmLnkaYPTrddjojVf3ps2NzeKbZ0r/i06seWLtEmgoFThjSkmQGLvLqfwSxzrg==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@qawolf/types/-/types-0.9.2.tgz",
+      "integrity": "sha512-dxJNuOb+Z3jcB/RW2VtjzvQiskYa2FhBQZ132AS2OyKr2E6CCCXLOqE7o+0v2/FFIibHNSre6JglRj3LawQ2mA==",
       "dev": true
     },
     "@qawolf/web": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/web/-/web-0.9.0.tgz",
-      "integrity": "sha512-liOeYWTlb1crzn+BYxL16j1BnmW14V4UM1XwGGGK0U4ZTwP99cM4B4lM/ej34WzaYNYLPfUl/4cBC/VqXF1+rA==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@qawolf/web/-/web-0.9.2.tgz",
+      "integrity": "sha512-I4rCBGmuCCxxhHtLYiT8/6BsOEFAgvPWciWq8owjql2Di8kmxSOFaZDVDiF7ZfwWTxNKPO6q6yGP38QfV8WpHQ==",
       "dev": true,
       "requires": {
         "@jperl/html-parse-stringify": "1.0.4"
@@ -19337,15 +19337,15 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qawolf": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/qawolf/-/qawolf-0.9.0.tgz",
-      "integrity": "sha512-lCH3S+TOs57ypqlXOovzu3QyUgXVczh/nqETxV1vnPyRNzLebWt4jpKB7x+awY07R19LQVD0KZBgjUBNNciVfQ==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/qawolf/-/qawolf-0.9.2.tgz",
+      "integrity": "sha512-KfQC4BQRHNGYm9GDhHpmJkSU4qbtxnuA/S4vvvOSKBm5nN/fpiLNoOK9Xn7/PkfZ0BYoYJXYZM+YCjPDpUzGFw==",
       "dev": true,
       "requires": {
-        "@qawolf/browser": "0.9.0",
-        "@qawolf/cli": "0.9.0",
-        "@qawolf/repl": "0.9.0",
-        "@qawolf/web": "0.9.0",
+        "@qawolf/browser": "0.9.2",
+        "@qawolf/cli": "0.9.2",
+        "@qawolf/repl": "0.9.2",
+        "@qawolf/web": "0.9.2",
         "fs-extra": "^8.1.0",
         "handlebars": "^4.7.3",
         "kleur": "^3.0.3",
@@ -19533,16 +19533,16 @@
           }
         },
         "@qawolf/cli": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/@qawolf/cli/-/cli-0.9.0.tgz",
-          "integrity": "sha512-YiLVSTtJGSADNyPV5lXXrBe0o569ABw/aohzlPgZLjrJldpR4QvoMExFTwHSDaUuXEagk/8dPqS1/sYscIGfHA==",
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/@qawolf/cli/-/cli-0.9.2.tgz",
+          "integrity": "sha512-ZGkceIIf7d94z2J8yxUaqDl1roXZeMy1Mzo0f0VRJ7mAF6L5ZtNjwmiZyDv0+fqHveefjFGeVg4ZKR/2/e6nKw==",
           "dev": true,
           "requires": {
-            "@qawolf/browser": "0.9.0",
-            "@qawolf/create-code": "0.9.0",
-            "@qawolf/jest-plugin": "0.9.0",
-            "@qawolf/logger": "0.9.0",
-            "@qawolf/repl": "0.9.0",
+            "@qawolf/browser": "0.9.2",
+            "@qawolf/create-code": "0.9.2",
+            "@qawolf/jest-plugin": "0.9.2",
+            "@qawolf/logger": "0.9.2",
+            "@qawolf/repl": "0.9.2",
             "commander": "^4.1.1",
             "inquirer": "^7.0.0",
             "jest": "^25.1.0"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "husky": "4.2.1",
     "lint-staged": "10.0.7",
     "prettier": "1.19.1",
-    "qawolf": "0.9.0",
+    "qawolf": "0.9.2",
     "stylelint": "13.1.0",
     "stylelint-config-prettier": "8.0.1",
     "stylelint-config-recommended": "3.0.0",


### PR DESCRIPTION
- Use `e2e` script to run tests (sets the test path correctly, [the command `npx qawolf --path=./e2e test`](https://docs.qawolf.com/docs/api/cli#npx-qawolf-test-name) should also work)
- Start the server with `npm run start` before running tests
- Update QA Wolf to latest version